### PR TITLE
Fix Binder configuration and align with openTEPES current version

### DIFF
--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,8 +1,0 @@
-jupyter-book>=0.7.0b
-pyomo
-matplotlib
-numpy
-pandas
-altair
-psutil
-openTEPES

--- a/environment.yml
+++ b/environment.yml
@@ -1,26 +1,30 @@
 name: openTEPES-tutorial
+channels:
+  - conda-forge
+  - defaults
 dependencies:
-          - python = 3.12.*
-          - altair
-          - cartopy
-          - coincbc
-          - colour
-          - glpk
-          - matplotlib
-          - numpy
-          - pandas
-          - pip
-          - plotly
-          - psutil
-          - pyomo
-          - pyscipopt
-          - scikit-learn
-          - scikit-learn-extra
-          - rise
-          - vega
-          - vega_datasets
-          - pip:
-              - docker
-              - openTEPES
-              - scipy
-              - highspy
+  - python=3.12
+  - altair
+  - coincbc
+  - colour
+  - glpk
+  - matplotlib
+  - numpy
+  - pandas
+  - pip
+  - plotly
+  - psutil
+  - pyomo
+  - scikit-learn
+  - scikit-learn-extra
+  - scipy
+  - duckdb
+  - streamlit
+  - rise
+  - vega
+  - vega_datasets
+  - jupyter-book
+  - pip:
+    - openTEPES
+    - tsam
+    - highspy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+openTEPES
+tsam
+highspy
+jupyter-book
+matplotlib
+numpy
+pandas
+pyomo
+altair
+psutil
+scikit-learn
+scikit-learn-extra
+scipy
+duckdb
+streamlit
+ausankey
+amplpy


### PR DESCRIPTION
Binder was failing to configure the repository due to several issues:
1. Incorrect casing of `Requirements.txt` (must be `requirements.txt`).
2. Missing dependencies like `tsam`, `highspy`, and `jupyter-book`.
3. Heavy and unused dependencies like `cartopy` causing build failures.
4. Lack of explicit channels in `environment.yml` leading to solver failures.

I have updated the configuration to align with the current requirements of the `openTEPES` model (https://github.com/IIT-EnergySystemModels/openTEPES) and fixed these issues. The environment now uses Python 3.12 and follows best practices for Binder.

---
*PR created automatically by Jules for task [11732358405987623959](https://jules.google.com/task/11732358405987623959) started by @erikfilias*