### PR TITLE
Trim Binder build context to fit mybinder.org limits

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -69,3 +69,15 @@ dmypy.json
 .pyre/
 desktop.ini
 .DS_Store
+
+# Trim the openTEPES submodule down to what the editable install needs
+# (pyproject.toml + the openTEPES/ Python package). Its bundled example cases,
+# case studies, docs and tests are large (~700 MB) and unused by the tutorial,
+# which has its own cases under notebooks/. Keeping them out of the build context
+# keeps the Binder image small enough for mybinder.org's build limits.
+external/openTEPES/openTEPES/cases/
+external/openTEPES/case_studies/
+external/openTEPES/doc/
+external/openTEPES/tests/
+external/openTEPES/scripts/
+external/openTEPES/.github/


### PR DESCRIPTION
The Binder image bundled the openTEPES submodule's example cases, case studies, docs and tests (~700 MB), which the tutorial never uses (it has its own cases under `notebooks/`). That pushes the image past mybinder.org's build limits, even though the repo2docker CI passes on GitHub's larger runners.

The editable install only needs `pyproject.toml` and the `openTEPES/` package, so this excludes the unused data via `.dockerignore`, shrinking the submodule's contribution from ~700 MB to ~2.5 MB. Verified locally that the editable install and `import openTEPES` still work without those directories.

The repo2docker CI on this PR builds the trimmed image and runs the demo notebook.
