### PR TITLE
Add a runnable parallel example to Sweep Mode A

### DIFF
--- a/notebooks/5.1-Sweep-Mode-A-PreBuild.ipynb
+++ b/notebooks/5.1-Sweep-Mode-A-PreBuild.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1dfaf484",
+   "id": "818d1429",
    "metadata": {},
    "source": [
     "# Sweep Mode A — Pre-build sweep\n",
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56480519",
+   "id": "b1335fca",
    "metadata": {},
    "source": [
     "## The question\n",
@@ -31,13 +31,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "99069d27",
+   "id": "a9163bc3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T15:03:00.893773Z",
-     "iopub.status.busy": "2026-06-29T15:03:00.893532Z",
-     "iopub.status.idle": "2026-06-29T15:03:01.181795Z",
-     "shell.execute_reply": "2026-06-29T15:03:01.181505Z"
+     "iopub.execute_input": "2026-06-29T19:20:12.175635Z",
+     "iopub.status.busy": "2026-06-29T19:20:12.175397Z",
+     "iopub.status.idle": "2026-06-29T19:20:12.455756Z",
+     "shell.execute_reply": "2026-06-29T19:20:12.455334Z"
     }
    },
    "outputs": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d7ec48b",
+   "id": "8678b714",
    "metadata": {},
    "source": [
     "## Run the sweep\n",
@@ -91,13 +91,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d12c9929",
+   "id": "9ed51376",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T15:03:01.183107Z",
-     "iopub.status.busy": "2026-06-29T15:03:01.183032Z",
-     "iopub.status.idle": "2026-06-29T15:03:12.228540Z",
-     "shell.execute_reply": "2026-06-29T15:03:12.228157Z"
+     "iopub.execute_input": "2026-06-29T19:20:12.456921Z",
+     "iopub.status.busy": "2026-06-29T19:20:12.456848Z",
+     "iopub.status.idle": "2026-06-29T19:20:23.085441Z",
+     "shell.execute_reply": "2026-06-29T19:20:23.085052Z"
     }
    },
    "outputs": [
@@ -119,24 +119,24 @@
       "Total cost o.f.      model formulation ****\n",
       "Investment elec      model formulation ****\n",
       "Period 2030, Scenario sc01, Stage st1\n",
-      "Generation oper o.f. model formulation ****\n"
+      "Generation oper o.f. model formulation ****\n",
+      "Investment & operation var constraints ****\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Investment & operation var constraints ****\n",
       "Inertia, oper resr, demand constraints ****\n",
       "Storage   scheduling       constraints ****\n",
-      "Unit commitment            constraints ****\n"
+      "Unit commitment            constraints ****\n",
+      "Ramp and min up/down time  constraints ****\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ramp and min up/down time  constraints ****\n",
       "Network    switching model constraints ****\n",
       "Network    operation model constraints ****\n",
       "Problem solving                        #### 1\n"
@@ -147,18 +147,18 @@
      "output_type": "stream",
      "text": [
       "Termination condition:  optimal\n",
-      "  Total system                 cost [MEUR]  159.2111765517769  Constraints 41136  Variables 50966  Seconds 4\n",
+      "  Total system                 cost [MEUR]  159.211176551777  Constraints 41136  Variables 50966  Seconds 3\n",
       "***** Period: 2030, Scenario: sc01, Stage: st1 ******\n",
       "  Total generation  investment cost [MEUR]  0\n",
       "  Total generation  retirement cost [MEUR]  0\n",
       "  Total reservoir   investment cost [MEUR]  0.0\n",
-      "  Total network     investment cost [MEUR]  4.041225328215885\n",
+      "  Total network     investment cost [MEUR]  4.0412253282158845\n",
       "  Total H2   pipe   investment cost [MEUR]  0.0\n",
       "  Total heat pipe   investment cost [MEUR]  0.0\n",
-      "  Total generation  operation  cost [MEUR]  155.16550622161094\n",
-      "  Total consumption operation  cost [MEUR]  0.0028532975065870803\n",
+      "  Total generation  operation  cost [MEUR]  155.16550622161125\n",
+      "  Total consumption operation  cost [MEUR]  0.002853297506587099\n",
       "  Total emission               cost [MEUR]  0.0\n",
-      "  Total network losses penalty cost [MEUR]  0.0015917044432770529\n",
+      "  Total network losses penalty cost [MEUR]  0.0015917044432770526\n",
       "  Total reliability electr     cost [MEUR]  0.0\n",
       "Writing            investment results  ...  0 s\n",
       "Writing          cost summary results  ...  0 s\n",
@@ -186,7 +186,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Setting up input data                  ...  1 s\n"
+      "Setting up input data                  ...  0 s\n"
      ]
     },
     {
@@ -225,7 +225,7 @@
      "output_type": "stream",
      "text": [
       "Termination condition:  optimal\n",
-      "  Total system                 cost [MEUR]  199.2279074895432  Constraints 41136  Variables 50966  Seconds 3\n",
+      "  Total system                 cost [MEUR]  199.22790748954316  Constraints 41136  Variables 50966  Seconds 3\n",
       "***** Period: 2030, Scenario: sc01, Stage: st1 ******\n",
       "  Total generation  investment cost [MEUR]  0\n",
       "  Total generation  retirement cost [MEUR]  0\n",
@@ -233,8 +233,8 @@
       "  Total network     investment cost [MEUR]  5.337109032001712\n",
       "  Total H2   pipe   investment cost [MEUR]  0.0\n",
       "  Total heat pipe   investment cost [MEUR]  0.0\n",
-      "  Total generation  operation  cost [MEUR]  193.88620417509878\n",
-      "  Total consumption operation  cost [MEUR]  0.0028444742272815686\n",
+      "  Total generation  operation  cost [MEUR]  193.88620417509864\n",
+      "  Total consumption operation  cost [MEUR]  0.0028444742272815543\n",
       "  Total emission               cost [MEUR]  0.0\n",
       "  Total network losses penalty cost [MEUR]  0.001749808215068684\n",
       "  Total reliability electr     cost [MEUR]  0.0\n",
@@ -276,13 +276,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "92708690",
+   "id": "e7457c8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T15:03:12.229570Z",
-     "iopub.status.busy": "2026-06-29T15:03:12.229495Z",
-     "iopub.status.idle": "2026-06-29T15:03:12.233487Z",
-     "shell.execute_reply": "2026-06-29T15:03:12.233189Z"
+     "iopub.execute_input": "2026-06-29T19:20:23.086388Z",
+     "iopub.status.busy": "2026-06-29T19:20:23.086325Z",
+     "iopub.status.idle": "2026-06-29T19:20:23.090725Z",
+     "shell.execute_reply": "2026-06-29T19:20:23.090416Z"
     }
    },
    "outputs": [
@@ -346,21 +346,285 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbb98396",
+   "id": "be8e96ef",
    "metadata": {},
    "source": [
     "## What just happened\n",
     "\n",
-    "Each case was solved on its own, and the total system cost rises in the high-demand scenario. A case that fails gets `status=\"error\"` instead of stopping the whole sweep.\n",
+    "Each case was solved on its own, and the total system cost rises in the high-demand scenario. A case that fails gets `status=\"error\"` instead of stopping the whole sweep."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12c5943e",
+   "metadata": {},
+   "source": [
+    "## Run the sweep in parallel\n",
     "\n",
-    "**Run in parallel.** Switch the backend to use several CPU cores:\n",
+    "The cases are independent, so they can solve at the same time on several CPU cores. Switch the backend to `\"multiprocessing\"` and choose how many workers to use. The summaries still come back in input order, so the result matches the serial run, just faster when there are many cases.\n",
     "\n",
-    "```python\n",
-    "records = openTEPES_Runner.run(cases, \"appsi_highs\", mode=\"pre-build\",\n",
-    "                               backend=\"multiprocessing\", n_workers=2)\n",
-    "```\n",
-    "\n",
-    "`backend=\"joblib\"` also works (needs `pip install joblib`).\n",
+    "Binder runs on Linux, where this works directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4677799e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T19:20:23.091677Z",
+     "iopub.status.busy": "2026-06-29T19:20:23.091623Z",
+     "iopub.status.idle": "2026-06-29T19:20:29.210054Z",
+     "shell.execute_reply": "2026-06-29T19:20:29.209565Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input data                             ****\n",
+      "Reading the CSV files                  ...  0 s\n",
+      "Reading    input data                  ...  0 s\n",
+      "Setting up input data                  ...  1 s\n",
+      "Setting up variables                   ...  0 s\n",
+      "Total cost o.f.      model formulation ****\n",
+      "Investment elec      model formulation ****\n",
+      "Period 2030, Scenario sc01, Stage st1\n",
+      "Generation oper o.f. model formulation ****\n",
+      "Investment & operation var constraints ****\n",
+      "Inertia, oper resr, demand constraints ****\n",
+      "Storage   scheduling       constraints ****\n",
+      "Unit commitment            constraints ****\n",
+      "Ramp and min up/down time  constraints ****\n",
+      "Network    switching model constraints ****\n",
+      "Network    operation model constraints ****\n",
+      "Problem solving                        #### 1\n",
+      "Input data                             ****\n",
+      "Reading the CSV files                  ...  0 s\n",
+      "Reading    input data                  ...  0 s\n",
+      "Setting up input data                  ...  1 s\n",
+      "Setting up variables                   ...  0 s\n",
+      "Total cost o.f.      model formulation ****\n",
+      "Investment elec      model formulation ****\n",
+      "Period 2030, Scenario sc01, Stage st1\n",
+      "Generation oper o.f. model formulation ****\n",
+      "Investment & operation var constraints ****\n",
+      "Inertia, oper resr, demand constraints ****\n",
+      "Storage   scheduling       constraints ****\n",
+      "Unit commitment            constraints ****\n",
+      "Ramp and min up/down time  constraints ****\n",
+      "Network    switching model constraints ****\n",
+      "Network    operation model constraints ****\n",
+      "Problem solving                        #### 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running HiGHS 1.14.0 (git hash: 7df0786): Copyright (c) 2026 under MIT licence terms\n",
+      "Running HiGHS 1.14.0 (git hash: 7df0786): Copyright (c) 2026 under MIT licence terms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LP has 41136 rows; 57516 cols; 166697 nonzeros\n",
+      "Coefficient ranges:\n",
+      "  Matrix  [1e-04, 2e+02]\n",
+      "  Cost    [1e+00, 1e+00]\n",
+      "  Bound   [1e-03, 1e+03]\n",
+      "  RHS     [1e-03, 5e+02]\n",
+      "Presolving model\n",
+      "36761 rows, 45853 cols, 138280 nonzeros 0s\n",
+      "28396 rows, 37478 cols, 126227 nonzeros 0s\n",
+      "Dependent equations search running on 5389 equations with time limit of 1000.00s\n",
+      "Dependent equations search removed 0 rows and 0 nonzeros in 0.00s (limit = 1000.00s)\n",
+      "26482 rows, 34839 cols, 131410 nonzeros 0s\n",
+      "Presolve reductions: rows 26482(-14654); columns 34839(-22677); nonzeros 131410(-35287) \n",
+      "Solving the presolved LP\n",
+      "Using dual simplex solver\n",
+      "  Iteration        Objective     Infeasibilities num(sum)\n",
+      "          0     0.0000000000e+00 Ph1: 0(0) 0.1s\n",
+      "      17287     1.9922790749e+02 Pr: 0(0); Du: 0(4.72514e-13) 1.9s\n",
+      "      17287     1.9922790749e+02 Pr: 0(0); Du: 0(4.72514e-13) 1.9s\n",
+      "\n",
+      "Performed postsolve\n",
+      "Solving the original LP from the solution after postsolve\n",
+      "\n",
+      "Model status        : Optimal\n",
+      "Simplex   iterations: 17287\n",
+      "Objective value     :  1.9922790749e+02\n",
+      "P-D objective error :  2.9171939497e-15\n",
+      "HiGHS run time      :          1.92\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LP has 41136 rows; 57516 cols; 166697 nonzeros\n",
+      "Coefficient ranges:\n",
+      "  Matrix  [1e-04, 2e+02]\n",
+      "  Cost    [1e+00, 1e+00]\n",
+      "  Bound   [9e-04, 1e+03]\n",
+      "  RHS     [9e-04, 5e+02]\n",
+      "Presolving model\n",
+      "36762 rows, 45854 cols, 138283 nonzeros 0s\n",
+      "28394 rows, 37474 cols, 126104 nonzeros 0s\n",
+      "Dependent equations search running on 5388 equations with time limit of 1000.00s\n",
+      "Dependent equations search removed 0 rows and 0 nonzeros in 0.00s (limit = 1000.00s)\n",
+      "26479 rows, 34834 cols, 131292 nonzeros 0s\n",
+      "Presolve reductions: rows 26479(-14657); columns 34834(-22682); nonzeros 131292(-35405) \n",
+      "Solving the presolved LP\n",
+      "Using dual simplex solver\n",
+      "  Iteration        Objective     Infeasibilities num(sum)\n",
+      "          0     0.0000000000e+00 Ph1: 0(0) 0.1s\n",
+      "      16688     1.5921117655e+02 Pr: 0(0) 2.1s\n",
+      "      16688     1.5921117655e+02 Pr: 0(0) 2.1s\n",
+      "\n",
+      "Performed postsolve\n",
+      "Solving the original LP from the solution after postsolve\n",
+      "\n",
+      "Model status        : Optimal\n",
+      "Simplex   iterations: 16688\n",
+      "Objective value     :  1.5921117655e+02\n",
+      "P-D objective error :  8.3639753464e-15\n",
+      "HiGHS run time      :          2.10\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Termination condition:  optimal\n",
+      "  Total system                 cost [MEUR]  159.2111765517772  Constraints 41136  Variables 50966  Seconds 4\n",
+      "***** Period: 2030, Scenario: sc01, Stage: st1 ******\n",
+      "  Total generation  investment cost [MEUR]  0\n",
+      "  Total generation  retirement cost [MEUR]  0\n",
+      "  Total reservoir   investment cost [MEUR]  0.0\n",
+      "  Total network     investment cost [MEUR]  4.041225328215885\n",
+      "  Total H2   pipe   investment cost [MEUR]  0.0\n",
+      "  Total heat pipe   investment cost [MEUR]  0.0\n",
+      "  Total generation  operation  cost [MEUR]  155.16550622161148\n",
+      "  Total consumption operation  cost [MEUR]  0.0028532975065870925\n",
+      "  Total emission               cost [MEUR]  0.0\n",
+      "  Total network losses penalty cost [MEUR]  0.0015917044432770533\n",
+      "  Total reliability electr     cost [MEUR]  0.0\n",
+      "Writing            investment results  ...  0 s\n",
+      "Writing          cost summary results  ...  0 s\n",
+      "Writing           KPI summary results  ...  0 s\n",
+      "Writing elect network summary results  ...  0 s\n",
+      "Writing              economic results  ...  0 s\n",
+      "Termination condition:  optimal\n",
+      "  Total system                 cost [MEUR]  199.2279074895432  Constraints 41136  Variables 50966  Seconds 3\n",
+      "***** Period: 2030, Scenario: sc01, Stage: st1 ******\n",
+      "  Total generation  investment cost [MEUR]  0\n",
+      "  Total generation  retirement cost [MEUR]  0\n",
+      "  Total reservoir   investment cost [MEUR]  0.0\n",
+      "  Total network     investment cost [MEUR]  5.337109032001712\n",
+      "  Total H2   pipe   investment cost [MEUR]  0.0\n",
+      "  Total heat pipe   investment cost [MEUR]  0.0\n",
+      "  Total generation  operation  cost [MEUR]  193.88620417509887\n",
+      "  Total consumption operation  cost [MEUR]  0.0028444742272815777\n",
+      "  Total emission               cost [MEUR]  0.0\n",
+      "  Total network losses penalty cost [MEUR]  0.001749808215068684\n",
+      "  Total reliability electr     cost [MEUR]  0.0\n",
+      "Writing            investment results  ...  0 s\n",
+      "Writing          cost summary results  ...  0 s\n",
+      "Writing           KPI summary results  ...  0 s\n",
+      "Writing elect network summary results  ...  0 s\n",
+      "Writing              economic results  ...  0 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "records_parallel = openTEPES_Runner.run(\n",
+    "    cases, \"appsi_highs\",\n",
+    "    mode=\"pre-build\", backend=\"multiprocessing\", n_workers=2,\n",
+    "    pIndOutputResults=0, pIndLogConsole=0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ee729cb8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T19:20:29.211212Z",
+     "iopub.status.busy": "2026-06-29T19:20:29.211139Z",
+     "iopub.status.idle": "2026-06-29T19:20:29.214760Z",
+     "shell.execute_reply": "2026-06-29T19:20:29.214458Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>label</th>\n",
+       "      <th>status</th>\n",
+       "      <th>total_cost_meur</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>base</td>\n",
+       "      <td>optimal</td>\n",
+       "      <td>159.211177</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>high_demand</td>\n",
+       "      <td>optimal</td>\n",
+       "      <td>199.227907</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         label   status  total_cost_meur\n",
+       "0         base  optimal       159.211177\n",
+       "1  high_demand  optimal       199.227907"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.DataFrame(records_parallel)[[\"label\", \"status\", \"total_cost_meur\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bef9381b",
+   "metadata": {},
+   "source": [
+    "`backend=\"joblib\"` works the same way (it needs `pip install joblib`). On a real sweep with many cases, raise `n_workers` to the number of cores you want to use.\n",
     "\n",
     "**Merge the results.** Pass `aggregate_to=\"sweepA_merged\"` to stack every case's result tables into one long table per result type, tagged by case label.\n",
     "\n",


### PR DESCRIPTION
Notebook `5.1` only described the `multiprocessing` backend in prose. This adds it as a real, executed cell that runs the same cases with `backend="multiprocessing", n_workers=2` and shows the results table, so new users see the parallel run actually working — same costs as the serial run, returned in input order.