### PR TITLE
Add a runnable aggregate_to example to Sweep Mode A

### DIFF
--- a/notebooks/5.1-Sweep-Mode-A-PreBuild.ipynb
+++ b/notebooks/5.1-Sweep-Mode-A-PreBuild.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "818d1429",
+   "id": "3a243cc3",
    "metadata": {},
    "source": [
     "# Sweep Mode A — Pre-build sweep\n",
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1335fca",
+   "id": "364eb3f8",
    "metadata": {},
    "source": [
     "## The question\n",
@@ -31,13 +31,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a9163bc3",
+   "id": "292b3e8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T19:20:12.175635Z",
-     "iopub.status.busy": "2026-06-29T19:20:12.175397Z",
-     "iopub.status.idle": "2026-06-29T19:20:12.455756Z",
-     "shell.execute_reply": "2026-06-29T19:20:12.455334Z"
+     "iopub.execute_input": "2026-06-29T19:35:49.539307Z",
+     "iopub.status.busy": "2026-06-29T19:35:49.539042Z",
+     "iopub.status.idle": "2026-06-29T19:35:49.824392Z",
+     "shell.execute_reply": "2026-06-29T19:35:49.824032Z"
     }
    },
    "outputs": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8678b714",
+   "id": "a8ff8bfd",
    "metadata": {},
    "source": [
     "## Run the sweep\n",
@@ -91,13 +91,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "9ed51376",
+   "id": "7ab805d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T19:20:12.456921Z",
-     "iopub.status.busy": "2026-06-29T19:20:12.456848Z",
-     "iopub.status.idle": "2026-06-29T19:20:23.085441Z",
-     "shell.execute_reply": "2026-06-29T19:20:23.085052Z"
+     "iopub.execute_input": "2026-06-29T19:35:49.825583Z",
+     "iopub.status.busy": "2026-06-29T19:35:49.825515Z",
+     "iopub.status.idle": "2026-06-29T19:36:00.382823Z",
+     "shell.execute_reply": "2026-06-29T19:36:00.382407Z"
     }
    },
    "outputs": [
@@ -147,18 +147,18 @@
      "output_type": "stream",
      "text": [
       "Termination condition:  optimal\n",
-      "  Total system                 cost [MEUR]  159.211176551777  Constraints 41136  Variables 50966  Seconds 3\n",
+      "  Total system                 cost [MEUR]  159.21117655177736  Constraints 41136  Variables 50966  Seconds 3\n",
       "***** Period: 2030, Scenario: sc01, Stage: st1 ******\n",
       "  Total generation  investment cost [MEUR]  0\n",
       "  Total generation  retirement cost [MEUR]  0\n",
       "  Total reservoir   investment cost [MEUR]  0.0\n",
-      "  Total network     investment cost [MEUR]  4.0412253282158845\n",
+      "  Total network     investment cost [MEUR]  4.041225328215885\n",
       "  Total H2   pipe   investment cost [MEUR]  0.0\n",
       "  Total heat pipe   investment cost [MEUR]  0.0\n",
-      "  Total generation  operation  cost [MEUR]  155.16550622161125\n",
-      "  Total consumption operation  cost [MEUR]  0.002853297506587099\n",
+      "  Total generation  operation  cost [MEUR]  155.16550622161148\n",
+      "  Total consumption operation  cost [MEUR]  0.0028532975065870933\n",
       "  Total emission               cost [MEUR]  0.0\n",
-      "  Total network losses penalty cost [MEUR]  0.0015917044432770526\n",
+      "  Total network losses penalty cost [MEUR]  0.0015917044432770533\n",
       "  Total reliability electr     cost [MEUR]  0.0\n",
       "Writing            investment results  ...  0 s\n",
       "Writing          cost summary results  ...  0 s\n",
@@ -186,28 +186,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Setting up input data                  ...  0 s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Setting up input data                  ...  0 s\n",
       "Setting up variables                   ...  0 s\n",
       "Total cost o.f.      model formulation ****\n",
       "Investment elec      model formulation ****\n",
       "Period 2030, Scenario sc01, Stage st1\n",
-      "Generation oper o.f. model formulation ****\n",
-      "Investment & operation var constraints ****\n",
-      "Inertia, oper resr, demand constraints ****\n",
-      "Storage   scheduling       constraints ****\n",
-      "Unit commitment            constraints ****\n"
+      "Generation oper o.f. model formulation ****\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Investment & operation var constraints ****\n",
+      "Inertia, oper resr, demand constraints ****\n",
+      "Storage   scheduling       constraints ****\n",
+      "Unit commitment            constraints ****\n",
       "Ramp and min up/down time  constraints ****\n",
       "Network    switching model constraints ****\n",
       "Network    operation model constraints ****\n"
@@ -230,11 +224,11 @@
       "  Total generation  investment cost [MEUR]  0\n",
       "  Total generation  retirement cost [MEUR]  0\n",
       "  Total reservoir   investment cost [MEUR]  0.0\n",
-      "  Total network     investment cost [MEUR]  5.337109032001712\n",
+      "  Total network     investment cost [MEUR]  5.3371090320017105\n",
       "  Total H2   pipe   investment cost [MEUR]  0.0\n",
       "  Total heat pipe   investment cost [MEUR]  0.0\n",
-      "  Total generation  operation  cost [MEUR]  193.88620417509864\n",
-      "  Total consumption operation  cost [MEUR]  0.0028444742272815543\n",
+      "  Total generation  operation  cost [MEUR]  193.8862041750987\n",
+      "  Total consumption operation  cost [MEUR]  0.0028444742272815595\n",
       "  Total emission               cost [MEUR]  0.0\n",
       "  Total network losses penalty cost [MEUR]  0.001749808215068684\n",
       "  Total reliability electr     cost [MEUR]  0.0\n",
@@ -276,13 +270,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "e7457c8d",
+   "id": "3380edf2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T19:20:23.086388Z",
-     "iopub.status.busy": "2026-06-29T19:20:23.086325Z",
-     "iopub.status.idle": "2026-06-29T19:20:23.090725Z",
-     "shell.execute_reply": "2026-06-29T19:20:23.090416Z"
+     "iopub.execute_input": "2026-06-29T19:36:00.383868Z",
+     "iopub.status.busy": "2026-06-29T19:36:00.383792Z",
+     "iopub.status.idle": "2026-06-29T19:36:00.387908Z",
+     "shell.execute_reply": "2026-06-29T19:36:00.387482Z"
     }
    },
    "outputs": [
@@ -346,7 +340,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be8e96ef",
+   "id": "b52a6101",
    "metadata": {},
    "source": [
     "## What just happened\n",
@@ -356,7 +350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12c5943e",
+   "id": "411a6fd5",
    "metadata": {},
    "source": [
     "## Run the sweep in parallel\n",
@@ -369,13 +363,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "4677799e",
+   "id": "dc68a8d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T19:20:23.091677Z",
-     "iopub.status.busy": "2026-06-29T19:20:23.091623Z",
-     "iopub.status.idle": "2026-06-29T19:20:29.210054Z",
-     "shell.execute_reply": "2026-06-29T19:20:29.209565Z"
+     "iopub.execute_input": "2026-06-29T19:36:00.388853Z",
+     "iopub.status.busy": "2026-06-29T19:36:00.388796Z",
+     "iopub.status.idle": "2026-06-29T19:36:06.364709Z",
+     "shell.execute_reply": "2026-06-29T19:36:06.364253Z"
     }
    },
    "outputs": [
@@ -439,26 +433,26 @@
       "  RHS     [1e-03, 5e+02]\n",
       "Presolving model\n",
       "36761 rows, 45853 cols, 138280 nonzeros 0s\n",
-      "28396 rows, 37478 cols, 126227 nonzeros 0s\n",
+      "28396 rows, 37478 cols, 126116 nonzeros 0s\n",
       "Dependent equations search running on 5389 equations with time limit of 1000.00s\n",
       "Dependent equations search removed 0 rows and 0 nonzeros in 0.00s (limit = 1000.00s)\n",
-      "26482 rows, 34839 cols, 131410 nonzeros 0s\n",
-      "Presolve reductions: rows 26482(-14654); columns 34839(-22677); nonzeros 131410(-35287) \n",
+      "26482 rows, 34839 cols, 131299 nonzeros 0s\n",
+      "Presolve reductions: rows 26482(-14654); columns 34839(-22677); nonzeros 131299(-35398) \n",
       "Solving the presolved LP\n",
       "Using dual simplex solver\n",
       "  Iteration        Objective     Infeasibilities num(sum)\n",
       "          0     0.0000000000e+00 Ph1: 0(0) 0.1s\n",
-      "      17287     1.9922790749e+02 Pr: 0(0); Du: 0(4.72514e-13) 1.9s\n",
-      "      17287     1.9922790749e+02 Pr: 0(0); Du: 0(4.72514e-13) 1.9s\n",
+      "      17019     1.9922790749e+02 Pr: 0(0); Du: 0(7.16127e-13) 1.6s\n",
+      "      17019     1.9922790749e+02 Pr: 0(0); Du: 0(7.16127e-13) 1.6s\n",
       "\n",
       "Performed postsolve\n",
       "Solving the original LP from the solution after postsolve\n",
       "\n",
       "Model status        : Optimal\n",
-      "Simplex   iterations: 17287\n",
+      "Simplex   iterations: 17019\n",
       "Objective value     :  1.9922790749e+02\n",
-      "P-D objective error :  2.9171939497e-15\n",
-      "HiGHS run time      :          1.92\n"
+      "P-D objective error :  2.5614385900e-15\n",
+      "HiGHS run time      :          1.64\n"
      ]
     },
     {
@@ -473,26 +467,26 @@
       "  RHS     [9e-04, 5e+02]\n",
       "Presolving model\n",
       "36762 rows, 45854 cols, 138283 nonzeros 0s\n",
-      "28394 rows, 37474 cols, 126104 nonzeros 0s\n",
+      "28394 rows, 37474 cols, 126094 nonzeros 0s\n",
       "Dependent equations search running on 5388 equations with time limit of 1000.00s\n",
       "Dependent equations search removed 0 rows and 0 nonzeros in 0.00s (limit = 1000.00s)\n",
-      "26479 rows, 34834 cols, 131292 nonzeros 0s\n",
-      "Presolve reductions: rows 26479(-14657); columns 34834(-22682); nonzeros 131292(-35405) \n",
+      "26479 rows, 34834 cols, 131282 nonzeros 0s\n",
+      "Presolve reductions: rows 26479(-14657); columns 34834(-22682); nonzeros 131282(-35415) \n",
       "Solving the presolved LP\n",
       "Using dual simplex solver\n",
       "  Iteration        Objective     Infeasibilities num(sum)\n",
       "          0     0.0000000000e+00 Ph1: 0(0) 0.1s\n",
-      "      16688     1.5921117655e+02 Pr: 0(0) 2.1s\n",
-      "      16688     1.5921117655e+02 Pr: 0(0) 2.1s\n",
+      "      17066     1.5921117655e+02 Pr: 0(0) 2.0s\n",
+      "      17066     1.5921117655e+02 Pr: 0(0) 2.0s\n",
       "\n",
       "Performed postsolve\n",
       "Solving the original LP from the solution after postsolve\n",
       "\n",
       "Model status        : Optimal\n",
-      "Simplex   iterations: 16688\n",
+      "Simplex   iterations: 17066\n",
       "Objective value     :  1.5921117655e+02\n",
-      "P-D objective error :  8.3639753464e-15\n",
-      "HiGHS run time      :          2.10\n"
+      "P-D objective error :  9.6986522634e-15\n",
+      "HiGHS run time      :          1.99\n"
      ]
     },
     {
@@ -500,7 +494,7 @@
      "output_type": "stream",
      "text": [
       "Termination condition:  optimal\n",
-      "  Total system                 cost [MEUR]  159.2111765517772  Constraints 41136  Variables 50966  Seconds 4\n",
+      "  Total system                 cost [MEUR]  159.21117655177747  Constraints 41136  Variables 50966  Seconds 3\n",
       "***** Period: 2030, Scenario: sc01, Stage: st1 ******\n",
       "  Total generation  investment cost [MEUR]  0\n",
       "  Total generation  retirement cost [MEUR]  0\n",
@@ -508,10 +502,10 @@
       "  Total network     investment cost [MEUR]  4.041225328215885\n",
       "  Total H2   pipe   investment cost [MEUR]  0.0\n",
       "  Total heat pipe   investment cost [MEUR]  0.0\n",
-      "  Total generation  operation  cost [MEUR]  155.16550622161148\n",
-      "  Total consumption operation  cost [MEUR]  0.0028532975065870925\n",
+      "  Total generation  operation  cost [MEUR]  155.16550622161174\n",
+      "  Total consumption operation  cost [MEUR]  0.0028532975065870907\n",
       "  Total emission               cost [MEUR]  0.0\n",
-      "  Total network losses penalty cost [MEUR]  0.0015917044432770533\n",
+      "  Total network losses penalty cost [MEUR]  0.001591704443277054\n",
       "  Total reliability electr     cost [MEUR]  0.0\n",
       "Writing            investment results  ...  0 s\n",
       "Writing          cost summary results  ...  0 s\n",
@@ -519,7 +513,7 @@
       "Writing elect network summary results  ...  0 s\n",
       "Writing              economic results  ...  0 s\n",
       "Termination condition:  optimal\n",
-      "  Total system                 cost [MEUR]  199.2279074895432  Constraints 41136  Variables 50966  Seconds 3\n",
+      "  Total system                 cost [MEUR]  199.22790748954313  Constraints 41136  Variables 50966  Seconds 3\n",
       "***** Period: 2030, Scenario: sc01, Stage: st1 ******\n",
       "  Total generation  investment cost [MEUR]  0\n",
       "  Total generation  retirement cost [MEUR]  0\n",
@@ -527,8 +521,8 @@
       "  Total network     investment cost [MEUR]  5.337109032001712\n",
       "  Total H2   pipe   investment cost [MEUR]  0.0\n",
       "  Total heat pipe   investment cost [MEUR]  0.0\n",
-      "  Total generation  operation  cost [MEUR]  193.88620417509887\n",
-      "  Total consumption operation  cost [MEUR]  0.0028444742272815777\n",
+      "  Total generation  operation  cost [MEUR]  193.8862041750986\n",
+      "  Total consumption operation  cost [MEUR]  0.0028444742272815513\n",
       "  Total emission               cost [MEUR]  0.0\n",
       "  Total network losses penalty cost [MEUR]  0.001749808215068684\n",
       "  Total reliability electr     cost [MEUR]  0.0\n",
@@ -551,13 +545,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "ee729cb8",
+   "id": "c3c191e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-29T19:20:29.211212Z",
-     "iopub.status.busy": "2026-06-29T19:20:29.211139Z",
-     "iopub.status.idle": "2026-06-29T19:20:29.214760Z",
-     "shell.execute_reply": "2026-06-29T19:20:29.214458Z"
+     "iopub.execute_input": "2026-06-29T19:36:06.365895Z",
+     "iopub.status.busy": "2026-06-29T19:36:06.365818Z",
+     "iopub.status.idle": "2026-06-29T19:36:06.369749Z",
+     "shell.execute_reply": "2026-06-29T19:36:06.369416Z"
     }
    },
    "outputs": [
@@ -621,13 +615,368 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bef9381b",
+   "id": "7786396c",
    "metadata": {},
    "source": [
-    "`backend=\"joblib\"` works the same way (it needs `pip install joblib`). On a real sweep with many cases, raise `n_workers` to the number of cores you want to use.\n",
+    "`backend=\"joblib\"` works the same way (it needs `pip install joblib`). On a real sweep with many cases, raise `n_workers` to the number of cores you want to use."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "302c1023",
+   "metadata": {},
+   "source": [
+    "## Collect every case's results into one table\n",
     "\n",
-    "**Merge the results.** Pass `aggregate_to=\"sweepA_merged\"` to stack every case's result tables into one long table per result type, tagged by case label.\n",
+    "So far we only compared the total cost. To compare the full results across cases, pass `aggregate_to` a folder. After the sweep, openTEPES stacks each result table across all cases into one long table, `oT_Sweep_<table>.csv`, with a leading `case` column.\n",
     "\n",
+    "This reads the per-case results from disk, so we turn result writing on with `pIndOutputResults=\"Yes\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e81674f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T19:36:06.370735Z",
+     "iopub.status.busy": "2026-06-29T19:36:06.370674Z",
+     "iopub.status.idle": "2026-06-29T19:36:18.407017Z",
+     "shell.execute_reply": "2026-06-29T19:36:18.406549Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input data                             ****\n",
+      "Reading the CSV files                  ...  0 s\n",
+      "Reading    input data                  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting up input data                  ...  1 s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting up variables                   ...  0 s\n",
+      "Total cost o.f.      model formulation ****\n",
+      "Investment elec      model formulation ****\n",
+      "Period 2030, Scenario sc01, Stage st1\n",
+      "Generation oper o.f. model formulation ****\n",
+      "Investment & operation var constraints ****\n",
+      "Inertia, oper resr, demand constraints ****\n",
+      "Storage   scheduling       constraints ****\n",
+      "Unit commitment            constraints ****\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ramp and min up/down time  constraints ****\n",
+      "Network    switching model constraints ****\n",
+      "Network    operation model constraints ****\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problem solving                        #### 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Termination condition:  optimal\n",
+      "  Total system                 cost [MEUR]  159.21117655177736  Constraints 41136  Variables 50966  Seconds 3\n",
+      "***** Period: 2030, Scenario: sc01, Stage: st1 ******\n",
+      "  Total generation  investment cost [MEUR]  0\n",
+      "  Total generation  retirement cost [MEUR]  0\n",
+      "  Total reservoir   investment cost [MEUR]  0.0\n",
+      "  Total network     investment cost [MEUR]  4.041225328215885\n",
+      "  Total H2   pipe   investment cost [MEUR]  0.0\n",
+      "  Total heat pipe   investment cost [MEUR]  0.0\n",
+      "  Total generation  operation  cost [MEUR]  155.16550622161148\n",
+      "  Total consumption operation  cost [MEUR]  0.0028532975065870933\n",
+      "  Total emission               cost [MEUR]  0.0\n",
+      "  Total network losses penalty cost [MEUR]  0.0015917044432770533\n",
+      "  Total reliability electr     cost [MEUR]  0.0\n",
+      "Writing            investment results  ...  0 s\n",
+      "Writing          cost summary results  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing           KPI summary results  ...  0 s\n",
+      "Writing elect network summary results  ...  0 s\n",
+      "Writing           reliability indexes  ...  0 s\n",
+      "Writing           flexibility results  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/private/tmp/claude-501/-Users-philias-ai-research-repos-openTEPES-tutorial/8f6d4ac5-9ff1-45bc-8a3c-5cc562abe3f1/scratchpad/venv312/lib/python3.12/site-packages/altair/utils/core.py:264: UserWarning: I don't know how to infer vegalite type from 'empty'.  Defaulting to nominal.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing  generation operation results  ...  0 s\n",
+      "Writing         ESS operation results  ...  0 s\n",
+      "Writing elect netwk operation results  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing  marginal information results  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing              economic results  ...  0 s\n",
+      "Plotting electricity network     maps  ...  0 s\n",
+      "Input data                             ****\n",
+      "Reading the CSV files                  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading    input data                  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting up input data                  ...  1 s\n",
+      "Setting up variables                   ...  0 s\n",
+      "Total cost o.f.      model formulation ****\n",
+      "Investment elec      model formulation ****\n",
+      "Period 2030, Scenario sc01, Stage st1\n",
+      "Generation oper o.f. model formulation ****\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Investment & operation var constraints ****\n",
+      "Inertia, oper resr, demand constraints ****\n",
+      "Storage   scheduling       constraints ****\n",
+      "Unit commitment            constraints ****\n",
+      "Ramp and min up/down time  constraints ****\n",
+      "Network    switching model constraints ****\n",
+      "Network    operation model constraints ****\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problem solving                        #### 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Termination condition:  optimal\n",
+      "  Total system                 cost [MEUR]  199.22790748954316  Constraints 41136  Variables 50966  Seconds 3\n",
+      "***** Period: 2030, Scenario: sc01, Stage: st1 ******\n",
+      "  Total generation  investment cost [MEUR]  0\n",
+      "  Total generation  retirement cost [MEUR]  0\n",
+      "  Total reservoir   investment cost [MEUR]  0.0\n",
+      "  Total network     investment cost [MEUR]  5.3371090320017105\n",
+      "  Total H2   pipe   investment cost [MEUR]  0.0\n",
+      "  Total heat pipe   investment cost [MEUR]  0.0\n",
+      "  Total generation  operation  cost [MEUR]  193.8862041750987\n",
+      "  Total consumption operation  cost [MEUR]  0.0028444742272815595\n",
+      "  Total emission               cost [MEUR]  0.0\n",
+      "  Total network losses penalty cost [MEUR]  0.001749808215068684\n",
+      "  Total reliability electr     cost [MEUR]  0.0\n",
+      "Writing            investment results  ...  0 s\n",
+      "Writing          cost summary results  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing           KPI summary results  ...  0 s\n",
+      "Writing elect network summary results  ...  0 s\n",
+      "Writing           reliability indexes  ...  0 s\n",
+      "Writing           flexibility results  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/private/tmp/claude-501/-Users-philias-ai-research-repos-openTEPES-tutorial/8f6d4ac5-9ff1-45bc-8a3c-5cc562abe3f1/scratchpad/venv312/lib/python3.12/site-packages/altair/utils/core.py:264: UserWarning: I don't know how to infer vegalite type from 'empty'.  Defaulting to nominal.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing  generation operation results  ...  0 s\n",
+      "Writing         ESS operation results  ...  0 s\n",
+      "Writing elect netwk operation results  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing  marginal information results  ...  0 s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing              economic results  ...  0 s\n",
+      "Plotting electricity network     maps  ...  0 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "records = openTEPES_Runner.run(\n",
+    "    cases, \"appsi_highs\",\n",
+    "    mode=\"pre-build\", backend=\"serial\",\n",
+    "    pIndOutputResults=\"Yes\", pIndLogConsole=\"No\",\n",
+    "    aggregate_to=\"sweepA_merged\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35db0846",
+   "metadata": {},
+   "source": [
+    "Each `oT_Sweep_*.csv` in `sweepA_merged/` holds every case's rows for one result, told apart by the `case` column. For example, the total generation per technology in each case:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4db52e7d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T19:36:18.408156Z",
+     "iopub.status.busy": "2026-06-29T19:36:18.408081Z",
+     "iopub.status.idle": "2026-06-29T19:36:18.412577Z",
+     "shell.execute_reply": "2026-06-29T19:36:18.412246Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Coal</th>\n",
+       "      <th>ESS</th>\n",
+       "      <th>Gas</th>\n",
+       "      <th>Nuclear</th>\n",
+       "      <th>Oil</th>\n",
+       "      <th>RES</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>case</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>base</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>10699.9</td>\n",
+       "      <td>52416.4</td>\n",
+       "      <td>280862.4</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>57746.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>high_demand</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>10666.8</td>\n",
+       "      <td>91387.5</td>\n",
+       "      <td>280862.4</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>57746.6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             Coal      ESS      Gas   Nuclear  Oil      RES\n",
+       "case                                                       \n",
+       "base          0.0  10699.9  52416.4  280862.4  0.0  57746.6\n",
+       "high_demand   0.0  10666.8  91387.5  280862.4  0.0  57746.6"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gen = pd.read_csv(\"sweepA_merged/oT_Sweep_TechnologyGeneration.csv\")\n",
+    "tech = [c for c in gen.columns if c not in (\"case\", \"Scenario\", \"Period\", \"LoadLevel\")]\n",
+    "gen.groupby(\"case\")[tech].sum().round(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c8c33d1",
+   "metadata": {},
+   "source": [
     "When your cases share most of their inputs, Mode A re-reads the same data for each one. The next notebook, [Mode B](5.2-Sweep-Mode-B-InMemory.ipynb), avoids that."
    ]
   }


### PR DESCRIPTION
Notebook `5.1` now demonstrates `aggregate_to` as a real, executed step: it runs the sweep with `pIndOutputResults="Yes"` and `aggregate_to="sweepA_merged"`, then reads the stacked `oT_Sweep_TechnologyGeneration.csv` and groups by `case` to compare total generation per technology across the cases. The output is embedded so users see the merged table.

Note: it passes `pIndOutputResults="Yes"` rather than the integer `1`, because `openTEPES_run`'s index map currently only accepts `0` / `"Yes"` / `"No"` (the integer `1` raises IndexError). Worth a small openTEPES fix later so the runner's own default works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)